### PR TITLE
change return values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.0] - 2020-04-16
+### Changed
+- [#7](https://github.com/walkersumida/senro/pull/7) Change return values from string to hash
+
 ## [0.4] - 2020-02-22
 ### Added
 - [#6](https://github.com/walkersumida/senro/pull/6) Add `query_params_formatter_query` method

--- a/README.md
+++ b/README.md
@@ -21,21 +21,34 @@ Or install it yourself as:
 
 ## Usage
 ### in Rails
+#### format sort
 
 ```ruby
 class ApplicationController < ActionController::Base # or ::API class
   include Senro::Controller
   before_action :query_params_formatter_sort
-  before_action :query_params_formatter_query
 end
 
+
 pp params['sort']
-# => 'id ASC, name DESC'
+# => { id: 'asc', name: 'desc' }
 pp params['original_sort']
 # => 'id,-name'
 
-# e.g.
+# e.g. in ActiveRecord
 @items = Item.all.order(params['sort'])
+
+# e.g. in Mongoid
+@items = Item.all.order_by(params['sort'])
+```
+
+#### format query
+
+```ruby
+class ApplicationController < ActionController::Base # or ::API class
+  include Senro::Controller
+  before_action :query_params_formatter_query
+end
 
 
 pp params['q']

--- a/lib/senro/query_params_formatter.rb
+++ b/lib/senro/query_params_formatter.rb
@@ -13,14 +13,13 @@ module Senro
     # @return [String] formated stirng
     def self.sort(param)
       attributes = param.split(',')
-      attributes.map! do |attr|
+      attributes.each_with_object({}) do |attr, hash|
         if /^\-/.match(attr).nil?
-          "#{attr.strip.gsub(/^\+/, '').underscore} ASC"
+          hash[attr.strip.gsub(/^\+/, '').underscore.to_sym] = 'asc'
         else
-          "#{attr.strip.gsub(/^\-/, '').underscore} DESC"
+          hash[attr.strip.gsub(/^\-/, '').underscore.to_sym] = 'desc'
         end
       end
-      attributes.join(', ')
     end
 
     # Format RESTful API's query params to SQL where clause.

--- a/lib/senro/version.rb
+++ b/lib/senro/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Senro
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/spec/senro/query_params_formatter/sort_spec.rb
+++ b/spec/senro/query_params_formatter/sort_spec.rb
@@ -4,19 +4,19 @@ RSpec.describe Senro::QueryParamsFormatter do
   describe '#sort' do
     context 'with +' do
       it 'returns order clause containing ASC' do
-        expect(Senro::QueryParamsFormatter.sort('+id')).to eq('id ASC')
+        expect(Senro::QueryParamsFormatter.sort('+id')).to eq({ id: 'asc' })
       end
     end
 
     context 'with -' do
       it 'returns order clause containing DESC' do
-        expect(Senro::QueryParamsFormatter.sort('-id')).to eq('id DESC')
+        expect(Senro::QueryParamsFormatter.sort('-id')).to eq({ id: 'desc' })
       end
     end
 
     context 'without + and -' do
       it 'returns order clause containing ASC' do
-        expect(Senro::QueryParamsFormatter.sort('id')).to eq('id ASC')
+        expect(Senro::QueryParamsFormatter.sort('id')).to eq({ id: 'asc' })
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Senro::QueryParamsFormatter do
       it 'returns correct order clause' do
         expect(
           Senro::QueryParamsFormatter.sort('+id,+name,created_at,-updated_at')
-        ).to eq('id ASC, name ASC, created_at ASC, updated_at DESC')
+        ).to eq({ id: 'asc', name: 'asc', created_at: 'asc', updated_at: 'desc' })
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe Senro::QueryParamsFormatter do
       it 'returns snake case attributes' do
         expect(
           Senro::QueryParamsFormatter.sort('+id,+name,createdAt,-updatedAt')
-        ).to eq('id ASC, name ASC, created_at ASC, updated_at DESC')
+        ).to eq({ id: 'asc', name: 'asc', created_at: 'asc', updated_at: 'desc' })
       end
     end
   end

--- a/spec/senro/requests/api/items_spec.rb
+++ b/spec/senro/requests/api/items_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe 'Api::Items', type: :request do
     it 'returns a formatted sort param' do
       get api_items_path, params: { sort: 'id' }
 
-      expect(response.request.env['action_controller.instance'].params['sort']).to eq('id ASC')
+      expect(response.request.env['action_controller.instance'].params['sort']).
+        to eq(ActionController::Parameters.new({ id: 'asc' }))
       expect(response.request.env['action_controller.instance'].params['original_sort']).to eq('id')
     end
   end
@@ -14,7 +15,8 @@ RSpec.describe 'Api::Items', type: :request do
     it 'returns a formatted sort param' do
       get api_items_path, params: { sort: 'id,-name' }
 
-      expect(response.request.env['action_controller.instance'].params['sort']).to eq('id ASC, name DESC')
+      expect(response.request.env['action_controller.instance'].params['sort']).
+        to eq(ActionController::Parameters.new({ id: 'asc', name: 'desc' }))
       expect(response.request.env['action_controller.instance'].params['original_sort']).to eq('id,-name')
     end
   end
@@ -24,7 +26,7 @@ RSpec.describe 'Api::Items', type: :request do
       get api_items_path, params: { q: 'is:open senro gem' }
 
       instance = response.request.env['action_controller.instance']
-      expect(instance.params['q'].to_unsafe_hash).
+      expect(instance.params['q']).
         to eq({ 'query' => 'senro gem', 'status' => { 'is' => ['open'] } })
       expect(instance.params['original_q']).to eq('is:open senro gem')
     end

--- a/spec/senro/requests/items_spec.rb
+++ b/spec/senro/requests/items_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe 'Items', type: :request do
     it 'returns a formatted sort param' do
       get items_path, params: { sort: 'id' }
 
-      expect(response.request.env['action_controller.instance'].params['sort']).to eq('id ASC')
+      expect(response.request.env['action_controller.instance'].params['sort']).
+        to eq(ActionController::Parameters.new(id: 'asc'))
       expect(response.request.env['action_controller.instance'].params['original_sort']).to eq('id')
     end
   end
@@ -14,7 +15,8 @@ RSpec.describe 'Items', type: :request do
     it 'returns a formatted sort param' do
       get items_path, params: { sort: 'id,-name' }
 
-      expect(response.request.env['action_controller.instance'].params['sort']).to eq('id ASC, name DESC')
+      expect(response.request.env['action_controller.instance'].params['sort']).
+        to eq(ActionController::Parameters.new({ id: 'asc', name: 'desc' }))
       expect(response.request.env['action_controller.instance'].params['original_sort']).to eq('id,-name')
     end
   end
@@ -24,7 +26,7 @@ RSpec.describe 'Items', type: :request do
       get items_path, params: { q: 'is:open senro gem' }
 
       instance = response.request.env['action_controller.instance']
-      expect(instance.params['q'].to_unsafe_hash).
+      expect(instance.params['q']).
         to eq({ 'query' => 'senro gem', 'status' => { 'is' => ['open'] } })
       expect(instance.params['original_q']).to eq('is:open senro gem')
     end


### PR DESCRIPTION
Change return values from string to hash.

__string__
```ruby
pp params['sort']
# => 'id ASC, name DESC'
```

__hash__
```ruby
pp params['sort']
# => { id: 'asc', name: 'desc' }

# can use on the mongoid too
Model.all.order_by(params['sort'])
```