### PR TITLE
fix datetime status bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.1] - 2020-04-16
+### Fixed
+- [#8](https://github.com/walkersumida/senro/pull/8) Fix a datetime status bug
+
 ## [0.5.0] - 2020-04-16
 ### Changed
 - [#7](https://github.com/walkersumida/senro/pull/7) Change return values from string to hash

--- a/lib/senro/query_params_formatter.rb
+++ b/lib/senro/query_params_formatter.rb
@@ -33,7 +33,7 @@ module Senro
       elements = param.split(' ')
       elements.each_with_object(data) do |ele, h|
         if ele.include? ':'
-          ary = ele.split(':')
+          ary = ele.split(':', 2)
           h[:status][ary[0].underscore.to_sym] =
             Array(h[:status][ary[0].underscore.to_sym]) << ary[1]
         else

--- a/lib/senro/version.rb
+++ b/lib/senro/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Senro
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/spec/senro/query_params_formatter/query_spec.rb
+++ b/spec/senro/query_params_formatter/query_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe Senro::QueryParamsFormatter do
         end
       end
 
+      context 'with datetime status' do
+        it 'returns a datetime status' do
+          expect(Senro::QueryParamsFormatter.query('from:2020-01-01T10:00:00+09:00')).to eq({
+            query: '',
+            status: { from: ['2020-01-01T10:00:00+09:00'] }
+          })
+        end
+      end
+
       context 'with multiple statuses' do
         it 'returns statuses' do
           expect(Senro::QueryParamsFormatter.query('is:open is:close')).to eq({


### PR DESCRIPTION
fix a following bug.

`GET /path?q=from:2020-10-10T10:00:00Z`

```ruby
pp params['q']['status']
# => { from: ['2020-10-10T10'] }
```